### PR TITLE
Fix a python 3 incompatible print statement

### DIFF
--- a/flaskext/coffee2js.py
+++ b/flaskext/coffee2js.py
@@ -22,7 +22,7 @@ def _convert(src, dst):
     outfile.write(output)
     outfile.close()
 
-    print 'compiled "%s" into "%s"' % (src, dst)
+    print('compiled "%s" into "%s"' % (src, dst))
 
 def coffee2js(app, js_folder='js', coffee_folder='src/coffee', force=False):
     if not hasattr(app, 'static_url_path'):


### PR DESCRIPTION
There is a single print statement which is not python3 compatible. Changing to wrap the print arguments in parentheses doesn't change the output, but makes the code python3 compatible.
